### PR TITLE
Change tap_google_analytics.group to string

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -1463,9 +1463,7 @@ components:
             - Traffic Sources
             - User
             - User Timings
-          type: array
-          items:
-            type: string
+          type: string
         behavior:
           description: >
             For Google Analytics and Google Ads sources only. The type of field. Possible values are:


### PR DESCRIPTION
Confirmed with Stitch support that `tap_google_analytics.group` should always be a string despite the docs saying it is an array